### PR TITLE
Improve compatibility with Windows CE

### DIFF
--- a/include/boost/dll/detail/windows/shared_library_impl.hpp
+++ b/include/boost/dll/detail/windows/shared_library_impl.hpp
@@ -134,10 +134,10 @@ public:
         }
 
         // Judging by the documentation of GetProcAddress
-        // there is no version for UNICODE, because
+        // there is no version for UNICODE on desktop/server Windows, because
         // names of functions are stored in narrow characters.
         void* const symbol = boost::dll::detail::aggressive_ptr_cast<void*>(
-            boost::detail::winapi::GetProcAddress(handle_, sb)
+            boost::detail::winapi::get_proc_address(handle_, sb)
         );
         if (symbol == NULL) {
             ec = boost::dll::detail::last_error_code();


### PR DESCRIPTION
Use winapi::get_proc_address() instead of winapi::GetProcAddress() in order to avoid hitting GetProcAddress macro that is defined on Windows CE and expands to GetProcAddressW.