### PR TITLE
dll: fix shared_library_impl::load()

### DIFF
--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -60,7 +60,7 @@ public:
         return *this;
     }
 
-    void load(const boost::filesystem::path sl, load_mode::type mode, boost::system::error_code &ec) {
+    void load(boost::filesystem::path sl, load_mode::type mode, boost::system::error_code &ec) {
         typedef int native_mode_t;
         unload();
 


### PR DESCRIPTION
the apple-codepath calls fs::path::swap, so it cannot be const