### PR TITLE
Update Boost.WinAPI usage to the new location and namespace

### DIFF
--- a/include/boost/dll/detail/pe_info.hpp
+++ b/include/boost/dll/detail/pe_info.hpp
@@ -26,7 +26,7 @@ namespace boost { namespace dll { namespace detail {
 // http://msdn.microsoft.com/en-us/magazine/cc301808.aspx
 //
 
-// Basic Windows typedefs. We can not use <boost/detail/winapi/basic_types.hpp> header
+// Basic Windows typedefs. We can not use <boost/winapi/basic_types.hpp> header
 // because that header must be included only on Windows platform
 typedef unsigned char BYTE_;
 typedef unsigned short WORD_;

--- a/include/boost/dll/detail/type_info.hpp
+++ b/include/boost/dll/detail/type_info.hpp
@@ -11,6 +11,10 @@
 
 #include <typeinfo>
 #include <cstring>
+#include <boost/config.hpp>
+#if defined(BOOST_MSVC) || defined(BOOST_MSVC_VER)
+#include <boost/winapi/basic_types.hpp>
+#endif
 
 namespace boost { namespace dll { namespace detail {
 
@@ -23,11 +27,11 @@ const std::type_info& load_type_info(Lib & lib, Storage & storage)
 {
     struct RTTICompleteObjectLocator
     {
-        boost::detail::winapi::DWORD_ signature; //always zero ?
-        boost::detail::winapi::DWORD_ offset;    //offset of this vtable in the complete class
-        boost::detail::winapi::DWORD_ cdOffset;  //constructor displacement offset
-        boost::detail::winapi::DWORD_ pTypeDescriptorOffset; //TypeDescriptor of the complete class
-        boost::detail::winapi::DWORD_ pClassDescriptorOffset; //describes inheritance hierarchy (ignored)
+        boost::winapi::DWORD_ signature; //always zero ?
+        boost::winapi::DWORD_ offset;    //offset of this vtable in the complete class
+        boost::winapi::DWORD_ cdOffset;  //constructor displacement offset
+        boost::winapi::DWORD_ pTypeDescriptorOffset; //TypeDescriptor of the complete class
+        boost::winapi::DWORD_ pClassDescriptorOffset; //describes inheritance hierarchy (ignored)
     };
 
     RTTICompleteObjectLocator** vtable_p = &lib.template get<RTTICompleteObjectLocator*>(storage.template get_vtable<Class>());
@@ -50,9 +54,9 @@ const std::type_info& load_type_info(Lib & lib, Storage & storage)
 {
     struct RTTICompleteObjectLocator
     {
-        boost::detail::winapi::DWORD_ signature; //always zero ?
-        boost::detail::winapi::DWORD_ offset;    //offset of this vtable in the complete class
-        boost::detail::winapi::DWORD_ cdOffset;  //constructor displacement offset
+        boost::winapi::DWORD_ signature; //always zero ?
+        boost::winapi::DWORD_ offset;    //offset of this vtable in the complete class
+        boost::winapi::DWORD_ cdOffset;  //constructor displacement offset
         const std::type_info* pTypeDescriptor; //TypeDescriptor of the complete class
         void* pClassDescriptor; //describes inheritance hierarchy (ignored)
     };

--- a/include/boost/dll/detail/windows/path_from_handle.hpp
+++ b/include/boost/dll/detail/windows/path_from_handle.hpp
@@ -10,8 +10,8 @@
 
 #include <boost/config.hpp>
 #include <boost/dll/detail/system_error.hpp>
-#include <boost/detail/winapi/dll.hpp>
-#include <boost/detail/winapi/get_last_error.hpp>
+#include <boost/winapi/dll.hpp>
+#include <boost/winapi/get_last_error.hpp>
 #include <boost/filesystem/path.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
@@ -21,29 +21,29 @@
 namespace boost { namespace dll { namespace detail {
 
     static inline boost::system::error_code last_error_code() BOOST_NOEXCEPT {
-        boost::detail::winapi::DWORD_ err = boost::detail::winapi::GetLastError();
+        boost::winapi::DWORD_ err = boost::winapi::GetLastError();
         return boost::system::error_code(
             err,
             boost::system::system_category()
         );
     }
 
-    inline boost::filesystem::path path_from_handle(boost::detail::winapi::HMODULE_ handle, boost::system::error_code &ec) {
-        BOOST_STATIC_CONSTANT(boost::detail::winapi::DWORD_, ERROR_INSUFFICIENT_BUFFER_ = 0x7A);
-        BOOST_STATIC_CONSTANT(boost::detail::winapi::DWORD_, DEFAULT_PATH_SIZE_ = 260);
+    inline boost::filesystem::path path_from_handle(boost::winapi::HMODULE_ handle, boost::system::error_code &ec) {
+        BOOST_STATIC_CONSTANT(boost::winapi::DWORD_, ERROR_INSUFFICIENT_BUFFER_ = 0x7A);
+        BOOST_STATIC_CONSTANT(boost::winapi::DWORD_, DEFAULT_PATH_SIZE_ = 260);
 
         // If `handle` parameter is NULL, GetModuleFileName retrieves the path of the
         // executable file of the current process.
-        boost::detail::winapi::WCHAR_ path_hldr[DEFAULT_PATH_SIZE_];
-        boost::detail::winapi::GetModuleFileNameW(handle, path_hldr, DEFAULT_PATH_SIZE_);
+        boost::winapi::WCHAR_ path_hldr[DEFAULT_PATH_SIZE_];
+        boost::winapi::GetModuleFileNameW(handle, path_hldr, DEFAULT_PATH_SIZE_);
         ec = last_error_code();
         if (!ec) {
             return boost::filesystem::path(path_hldr);
         }
 
-        for (unsigned i = 2; i < 1025 && static_cast<boost::detail::winapi::DWORD_>(ec.value()) == ERROR_INSUFFICIENT_BUFFER_; i *= 2) {
+        for (unsigned i = 2; i < 1025 && static_cast<boost::winapi::DWORD_>(ec.value()) == ERROR_INSUFFICIENT_BUFFER_; i *= 2) {
             std::wstring p(DEFAULT_PATH_SIZE_ * i, L'\0');
-            const std::size_t size = boost::detail::winapi::GetModuleFileNameW(handle, &p[0], DEFAULT_PATH_SIZE_ * i);
+            const std::size_t size = boost::winapi::GetModuleFileNameW(handle, &p[0], DEFAULT_PATH_SIZE_ * i);
             ec = last_error_code();
 
             if (!ec) {

--- a/include/boost/dll/detail/windows/shared_library_impl.hpp
+++ b/include/boost/dll/detail/windows/shared_library_impl.hpp
@@ -19,7 +19,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
-#include <boost/detail/winapi/dll.hpp>
+#include <boost/winapi/dll.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 # pragma once
@@ -31,7 +31,7 @@ class shared_library_impl {
     BOOST_MOVABLE_BUT_NOT_COPYABLE(shared_library_impl)
 
 public:
-    typedef boost::detail::winapi::HMODULE_ native_handle_t;
+    typedef boost::winapi::HMODULE_ native_handle_t;
 
     shared_library_impl() BOOST_NOEXCEPT
         : handle_(NULL)
@@ -53,7 +53,7 @@ public:
     }
 
     void load(boost::filesystem::path sl, load_mode::type mode, boost::system::error_code &ec) {
-        typedef boost::detail::winapi::DWORD_ native_mode_t;
+        typedef boost::winapi::DWORD_ native_mode_t;
         unload();
 
         if (!sl.is_absolute() && !(mode & load_mode::search_system_folders)) {
@@ -71,11 +71,11 @@ public:
         if (!!(mode & load_mode::append_decorations)) {
             mode &= ~load_mode::append_decorations;
 
-            handle_ = boost::detail::winapi::LoadLibraryExW((sl.native() + L".dll").c_str(), 0, static_cast<native_mode_t>(mode));
+            handle_ = boost::winapi::LoadLibraryExW((sl.native() + L".dll").c_str(), 0, static_cast<native_mode_t>(mode));
             if (!handle_) {
                 // MinGW loves 'lib' prefix and puts it even on Windows platform
                 const boost::filesystem::path load_path = (sl.has_parent_path() ? sl.parent_path() / L"lib" : L"lib").native() + sl.filename().native() + L".dll";
-                handle_ = boost::detail::winapi::LoadLibraryExW(
+                handle_ = boost::winapi::LoadLibraryExW(
                     load_path.c_str(),
                     0,
                     static_cast<native_mode_t>(mode)
@@ -95,9 +95,9 @@ public:
         // we have some path. So we do not check for path, only for extension. We can not be sure that
         // such behavior remain across all platforms, so we add L"." by hand.
         if (sl.has_extension()) {
-            handle_ = boost::detail::winapi::LoadLibraryExW(sl.c_str(), 0, static_cast<native_mode_t>(mode));
+            handle_ = boost::winapi::LoadLibraryExW(sl.c_str(), 0, static_cast<native_mode_t>(mode));
         } else {
-            handle_ = boost::detail::winapi::LoadLibraryExW((sl.native() + L".").c_str(), 0, static_cast<native_mode_t>(mode));
+            handle_ = boost::winapi::LoadLibraryExW((sl.native() + L".").c_str(), 0, static_cast<native_mode_t>(mode));
         }
 
         // LoadLibraryExW method is capable of self loading from program_location() path. No special actions
@@ -114,7 +114,7 @@ public:
 
     void unload() BOOST_NOEXCEPT {
         if (handle_) {
-            boost::detail::winapi::FreeLibrary(handle_);
+            boost::winapi::FreeLibrary(handle_);
             handle_ = 0;
         }
     }
@@ -148,7 +148,7 @@ public:
         // there is no version for UNICODE on desktop/server Windows, because
         // names of functions are stored in narrow characters.
         void* const symbol = boost::dll::detail::aggressive_ptr_cast<void*>(
-            boost::detail::winapi::get_proc_address(handle_, sb)
+            boost::winapi::get_proc_address(handle_, sb)
         );
         if (symbol == NULL) {
             ec = boost::dll::detail::last_error_code();
@@ -164,7 +164,7 @@ public:
 private:
     bool is_resource() const BOOST_NOEXCEPT {
         return false; /*!!(
-            reinterpret_cast<boost::detail::winapi::ULONG_PTR_>(handle_) & static_cast<boost::detail::winapi::ULONG_PTR_>(3)
+            reinterpret_cast<boost::winapi::ULONG_PTR_>(handle_) & static_cast<boost::winapi::ULONG_PTR_>(3)
         );*/
     }
 

--- a/include/boost/dll/runtime_symbol_info.hpp
+++ b/include/boost/dll/runtime_symbol_info.hpp
@@ -13,7 +13,7 @@
 #include <boost/predef/compiler/visualc.h>
 #include <boost/dll/detail/aggressive_ptr_cast.hpp>
 #if BOOST_OS_WINDOWS
-#   include <boost/detail/winapi/dll.hpp>
+#   include <boost/winapi/dll.hpp>
 #   include <boost/dll/detail/windows/path_from_handle.hpp>
 #else
 #   include <dlfcn.h>
@@ -69,13 +69,13 @@ namespace detail {
         const void* ptr = boost::dll::detail::aggressive_ptr_cast<const void*>(ptr_to_symbol);
 
 #if BOOST_OS_WINDOWS
-        boost::detail::winapi::MEMORY_BASIC_INFORMATION_ mbi;
-        if (!boost::detail::winapi::VirtualQuery(ptr, &mbi, sizeof(mbi))) {
+        boost::winapi::MEMORY_BASIC_INFORMATION_ mbi;
+        if (!boost::winapi::VirtualQuery(ptr, &mbi, sizeof(mbi))) {
             ec = boost::dll::detail::last_error_code();
             return ret;
         }
 
-        return boost::dll::detail::path_from_handle(reinterpret_cast<boost::detail::winapi::HMODULE_>(mbi.AllocationBase), ec);
+        return boost::dll::detail::path_from_handle(reinterpret_cast<boost::winapi::HMODULE_>(mbi.AllocationBase), ec);
 #else
         Dl_info info;
 

--- a/include/boost/dll/shared_library_load_mode.hpp
+++ b/include/boost/dll/shared_library_load_mode.hpp
@@ -13,8 +13,7 @@
 #include <boost/predef/library/c.h>
 
 #if BOOST_OS_WINDOWS
-//#include <boost/detail/winapi/dll.hpp>
-#include <boost/detail/winapi/dll.hpp>
+#   include <boost/winapi/dll.hpp>
 #else
 #   include <dlfcn.h>
 #endif
@@ -175,9 +174,9 @@ enum type {
     search_system_folders
 #elif BOOST_OS_WINDOWS
     default_mode                          = 0,
-    dont_resolve_dll_references           = boost::detail::winapi::DONT_RESOLVE_DLL_REFERENCES_,
-    load_ignore_code_authz_level          = boost::detail::winapi::LOAD_IGNORE_CODE_AUTHZ_LEVEL_,
-    load_with_altered_search_path         = boost::detail::winapi::LOAD_WITH_ALTERED_SEARCH_PATH_,
+    dont_resolve_dll_references           = boost::winapi::DONT_RESOLVE_DLL_REFERENCES_,
+    load_ignore_code_authz_level          = boost::winapi::LOAD_IGNORE_CODE_AUTHZ_LEVEL_,
+    load_with_altered_search_path         = boost::winapi::LOAD_WITH_ALTERED_SEARCH_PATH_,
     rtld_lazy                             = 0,
     rtld_now                              = 0,
     rtld_global                           = 0,


### PR DESCRIPTION
The PR also adds missing includes in `boost/dll/detail/type_info.hpp`.