### PR TITLE
- Expose and implement append_decorations method to build the library…

### DIFF
--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -48,7 +48,7 @@ public:
     ~shared_library_impl() BOOST_NOEXCEPT {
         unload();
     }
-    
+
     shared_library_impl(BOOST_RV_REF(shared_library_impl) sl) BOOST_NOEXCEPT
         : handle_(sl.handle_)
     {
@@ -58,6 +58,16 @@ public:
     shared_library_impl & operator=(BOOST_RV_REF(shared_library_impl) sl) BOOST_NOEXCEPT {
         swap(sl);
         return *this;
+    }
+
+    static boost::filesystem::path append_decorations(boost::filesystem::path sl) {
+        boost::filesystem::path actual_path = (
+            std::strncmp(sl.filename().string().c_str(), "lib", 3)
+            ? (sl.has_parent_path() ? sl.parent_path() / L"lib" : L"lib").native() + sl.filename().native()
+            : sl
+        );
+        actual_path += suffix();
+        return actual_path;
     }
 
     void load(boost::filesystem::path sl, load_mode::type mode, boost::system::error_code &ec) {
@@ -105,16 +115,21 @@ public:
         if (!!(mode & load_mode::append_decorations)) {
             mode &= ~load_mode::append_decorations;
 
-            boost::filesystem::path actual_path = (
-                std::strncmp(sl.filename().string().c_str(), "lib", 3)
-                ? (sl.has_parent_path() ? sl.parent_path() / L"lib" : L"lib").native() + sl.filename().native()
-                : sl
-            );
-            actual_path += suffix();
+            boost::filesystem::path actual_path = append_decorations(sl);
 
             handle_ = dlopen(actual_path.c_str(), static_cast<native_mode_t>(mode));
             if (handle_) {
                 boost::dll::detail::reset_dlerror();
+                return;
+            }
+            boost::system::error_code prog_loc_err;
+            boost::filesystem::path loc = boost::dll::detail::program_location_impl(prog_loc_err);
+            if (boost::filesystem::exists(actual_path) && !boost::filesystem::equivalent(sl, loc, prog_loc_err)) {
+                // decorated path exists : current error is not a bad file descriptor and we are not trying to load the executable itself
+                ec = boost::system::error_code(
+                    boost::system::errc::bad_file_descriptor,
+                    boost::system::generic_category()
+                );
                 return;
             }
         }
@@ -137,9 +152,9 @@ public:
         boost::system::error_code prog_loc_err;
         boost::filesystem::path loc = boost::dll::detail::program_location_impl(prog_loc_err);
         if (!prog_loc_err && boost::filesystem::equivalent(sl, loc, prog_loc_err) && !prog_loc_err) {
-            // As is known the function dlopen() loads the dynamic library file 
-            // named by the null-terminated string filename and returns an opaque 
-            // "handle" for the dynamic library. If filename is NULL, then the 
+            // As is known the function dlopen() loads the dynamic library file
+            // named by the null-terminated string filename and returns an opaque
+            // "handle" for the dynamic library. If filename is NULL, then the
             // returned handle is for the main program.
             ec.clear();
             boost::dll::detail::reset_dlerror();
@@ -212,4 +227,3 @@ private:
 }}} // boost::dll::detail
 
 #endif // BOOST_DLL_SHARED_LIBRARY_IMPL_HPP
-

--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -60,7 +60,7 @@ public:
         return *this;
     }
 
-    static boost::filesystem::path append_decorations(boost::filesystem::path sl) {
+    static boost::filesystem::path decorate(const boost::filesystem::path & sl) {
         boost::filesystem::path actual_path = (
             std::strncmp(sl.filename().string().c_str(), "lib", 3)
             ? (sl.has_parent_path() ? sl.parent_path() / L"lib" : L"lib").native() + sl.filename().native()
@@ -115,7 +115,7 @@ public:
         if (!!(mode & load_mode::append_decorations)) {
             mode &= ~load_mode::append_decorations;
 
-            boost::filesystem::path actual_path = append_decorations(sl);
+            boost::filesystem::path actual_path = decorate(sl);
 
             handle_ = dlopen(actual_path.c_str(), static_cast<native_mode_t>(mode));
             if (handle_) {

--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -127,7 +127,7 @@ public:
             if (boost::filesystem::exists(actual_path) && !boost::filesystem::equivalent(sl, loc, prog_loc_err)) {
                 // decorated path exists : current error is not a bad file descriptor and we are not trying to load the executable itself
                 ec = boost::system::error_code(
-                    boost::system::errc::bad_file_descriptor,
+                    boost::system::errc::executable_format_error,
                     boost::system::generic_category()
                 );
                 return;

--- a/include/boost/dll/detail/windows/shared_library_impl.hpp
+++ b/include/boost/dll/detail/windows/shared_library_impl.hpp
@@ -52,7 +52,7 @@ public:
         return *this;
     }
 
-    static boost::filesystem::path append_decorations(boost::filesystem::path sl) {
+    static boost::filesystem::path decorate(const boost::filesystem::path & sl) {
         boost::filesystem::path actual_path = sl;
         actual_path += suffix();
         if (!boost::filesystem::exists(actual_path)) {
@@ -81,7 +81,7 @@ public:
         if (!!(mode & load_mode::append_decorations)) {
             mode &= ~load_mode::append_decorations;
 
-            const boost::filesystem::path load_path = append_decorations(sl);
+            const boost::filesystem::path load_path = decorate(sl);
             handle_ = boost::winapi::LoadLibraryExW(
                 load_path.c_str(),
                 0,
@@ -89,6 +89,11 @@ public:
             );
 
             if (handle_) {
+                return;
+            }
+            if (boost::filesystem::exists(load_path)) {
+                // decorated path exists : current error is not a bad file descriptor
+                ec = boost::dll::detail::last_error_code();
                 return;
             }
         }

--- a/include/boost/dll/detail/windows/shared_library_impl.hpp
+++ b/include/boost/dll/detail/windows/shared_library_impl.hpp
@@ -40,7 +40,7 @@ public:
     ~shared_library_impl() BOOST_NOEXCEPT {
         unload();
     }
-    
+
     shared_library_impl(BOOST_RV_REF(shared_library_impl) sl) BOOST_NOEXCEPT
         : handle_(sl.handle_)
     {
@@ -50,6 +50,16 @@ public:
     shared_library_impl & operator=(BOOST_RV_REF(shared_library_impl) sl) BOOST_NOEXCEPT {
         swap(sl);
         return *this;
+    }
+
+    static boost::filesystem::path append_decorations(boost::filesystem::path sl) {
+        boost::filesystem::path actual_path = sl;
+        actual_path += suffix();
+        if (!boost::filesystem::exists(actual_path)) {
+            // MinGW loves 'lib' prefix and puts it even on Windows platform
+            actual_path = (sl.has_parent_path() ? sl.parent_path() / L"lib" : L"lib").native() + sl.filename().native() + suffix().native();
+        }
+        return actual_path;
     }
 
     void load(boost::filesystem::path sl, load_mode::type mode, boost::system::error_code &ec) {
@@ -71,16 +81,12 @@ public:
         if (!!(mode & load_mode::append_decorations)) {
             mode &= ~load_mode::append_decorations;
 
-            handle_ = boost::winapi::LoadLibraryExW((sl.native() + L".dll").c_str(), 0, static_cast<native_mode_t>(mode));
-            if (!handle_) {
-                // MinGW loves 'lib' prefix and puts it even on Windows platform
-                const boost::filesystem::path load_path = (sl.has_parent_path() ? sl.parent_path() / L"lib" : L"lib").native() + sl.filename().native() + L".dll";
-                handle_ = boost::winapi::LoadLibraryExW(
-                    load_path.c_str(),
-                    0,
-                    static_cast<native_mode_t>(mode)
-                );
-            }
+            const boost::filesystem::path load_path = append_decorations(sl);
+            handle_ = boost::winapi::LoadLibraryExW(
+                load_path.c_str(),
+                0,
+                static_cast<native_mode_t>(mode)
+            );
 
             if (handle_) {
                 return;
@@ -174,4 +180,3 @@ private:
 }}} // boost::dll::detail
 
 #endif // BOOST_DLL_SHARED_LIBRARY_IMPL_HPP
-

--- a/include/boost/dll/shared_library.hpp
+++ b/include/boost/dll/shared_library.hpp
@@ -511,8 +511,24 @@ public:
         return base_t::suffix();
     }
 
-    static boost::filesystem::path append_decorations(boost::filesystem::path sl) {
-        return base_t::append_decorations(sl);
+    /*!
+    * Returns the decorated path to a shared module name, i.e. with needed prefix/suffix added.
+    * For instance, for a path like "path/to/boost" it returns :
+    * - path/to/libboost.so on posix platforms
+    * - path/to/libboost.dylib on OSX
+    * - path/to/boost.dll on Windows
+    *
+    * This method handles both relative and absolute paths.
+    *
+    * - Windows note : if the decorated filepath (with its suffix appended) doesn't exist, decorate() prepends "lib" to the decorated path (for Mingw compatibility purpose)
+    * - Posix note : if the initial module name is already prepended with lib, only the suffix() is appended to the path
+    *
+    * \param sl the module name and path to decorate - for instance : /usr/lib/boost
+    *
+    * \return The decorated path (the final decorated path may not exists in the filesystem to avoid a supplementary check. The final check is performed using load(). Library user's can also check for the decorated path existenz.)
+    */
+    static boost::filesystem::path decorate(const boost::filesystem::path & sl) {
+        return base_t::decorate(sl);
     }
 
     /*!

--- a/include/boost/dll/shared_library.hpp
+++ b/include/boost/dll/shared_library.hpp
@@ -55,7 +55,7 @@ class shared_library
 public:
 #ifdef BOOST_DLL_DOXYGEN
     typedef platform_specific native_handle_t;
-#else 
+#else
     typedef shared_library_impl::native_handle_t native_handle_t;
 #endif
 
@@ -511,6 +511,10 @@ public:
         return base_t::suffix();
     }
 
+    static boost::filesystem::path append_decorations(boost::filesystem::path sl) {
+        return base_t::append_decorations(sl);
+    }
+
     /*!
     * Swaps two libraries. Does not invalidate existing symbols and functions loaded from libraries.
     *
@@ -547,4 +551,3 @@ inline void swap(shared_library& lhs, shared_library& rhs) BOOST_NOEXCEPT {
 }} // boost::dll
 
 #endif // BOOST_DLL_SHARED_LIBRARY_HPP
-


### PR DESCRIPTION
… path without loading the library.

It allows to get the concrete path that will be loaded and allows the user to use the concrete path prior to effectively load the library.
- #22 (which is similar to #19) issue proposal fix :Add error handling for posix platforms (gnu compiler compilation) when a library with missing symbols is asked for loading : check the library path exists and we do not try to load the current executable.
In this case : return the current dlerror (useless to try the exactly specified path as the decorated path points to a valid shared library file).