### PR TITLE
Remove unneeded convert from wchar_t to char on POSIX environment

### DIFF
--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -62,7 +62,7 @@ public:
     static boost::dll::fs::path decorate(const boost::dll::fs::path & sl) {
         boost::dll::fs::path actual_path = (
             std::strncmp(sl.filename().string().c_str(), "lib", 3)
-            ? boost::dll::fs::path((sl.has_parent_path() ? sl.parent_path() / L"lib" : L"lib").native() + sl.filename().native())
+            ? boost::dll::fs::path((sl.has_parent_path() ? sl.parent_path() / "lib" : "lib").native() + sl.filename().native())
             : sl
         );
         actual_path += suffix();


### PR DESCRIPTION
On POSIX environment ``fs::path::value_type`` is ``char`` (https://isocpp.org/files/papers/P0218r1.html#value_type, https://en.cppreference.com/w/cpp/filesystem/path).
Using a ``wchar_t`` string and converting from ``wchar_t`` to ``char`` is not required.