### PR TITLE
Construct string with iterators

### DIFF
--- a/include/boost/dll/detail/elf_info.hpp
+++ b/include/boost/dll/detail/elf_info.hpp
@@ -278,7 +278,7 @@ public:
         ret.reserve(symbols.size());
         for (std::size_t i = 0; i < symbols.size(); ++i) {
             if (is_visible(symbols[i]) && symbols[i].st_name < text.size()) {
-                ret.push_back(&text[symbols[i].st_name]);
+                ret.emplace_back(text.begin() + symbols[i].st_name, text.end());
                 if (ret.back().empty()) {
                     ret.pop_back(); // Do not show empty names
                 }
@@ -325,7 +325,7 @@ public:
 
         for (std::size_t i = 0; i < symbols.size(); ++i) {
             if (symbols[i].st_shndx == index && is_visible(symbols[i]) && symbols[i].st_name < text.size()) {
-                ret.push_back(&text[symbols[i].st_name]);
+                ret.emplace_back(text.begin() + symbols[i].st_name, text.end());
                 if (ret.back().empty()) {
                     ret.pop_back(); // Do not show empty names
                 }


### PR DESCRIPTION
Using iterators to construct the string instead of using a char* which depends on a null character being at the end.
The reason this came up is because of a static code analyzer flagged this and said that this depends on the null character being there. I am sure that it is working just fine, but that the iterators are just slightly better (and a little easier to read in my opinion). I would like to know what you think of this change though, hence why I am making a pull. This way you can see it and tell me why it is a bad idea. Or if you do like it, then you can accept the pull.