### PR TITLE
Use relative URL for redirect in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
  Distributed under the Boost Software License,
  Version 1.0. (See accompanying file LICENSE_1_0.txt
  or copy at http://boost.org/LICENSE_1_0.txt)
+
+boost-no-inspect
 -->
 <html>
 <head>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=https://www.boost.org/doc/libs/master/doc/html/boost_dll.html">
+<meta http-equiv="refresh" content="0; url=../../doc/html/boost_dll.html">
 <title>Boost.TypeIndex</title>
 <style>
   body {
@@ -26,7 +26,7 @@
 <body>
   <p>
     Automatic redirection failed, please go to
-    <a href="https://www.boost.org/doc/libs/master/doc/html/boost_dll.html">https://www.boost.org/doc/libs/master/doc/html/boost_dll.html</a>
+    <a href="../../doc/html/boost_dll.html">../../doc/html/boost_dll.html</a>
   </p>
   <p>
     &copy; Antony Polukhin, 2014-2023


### PR DESCRIPTION
Makes redirect in index.html consistent with other boost libraries. This also works when browsing HTML files locally (release archive).