### PR TITLE
Switch to `boost::core::invoke_swap`

### DIFF
--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -14,7 +14,7 @@
 #include <boost/dll/detail/posix/program_location_impl.hpp>
 
 #include <boost/move/utility.hpp>
-#include <boost/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/predef/os.h>
 
 #include <dlfcn.h>
@@ -177,7 +177,7 @@ public:
     }
 
     void swap(shared_library_impl& rhs) BOOST_NOEXCEPT {
-        boost::swap(handle_, rhs.handle_);
+        boost::core::invoke_swap(handle_, rhs.handle_);
     }
 
     boost::dll::fs::path full_module_path(boost::dll::fs::error_code &ec) const {

--- a/include/boost/dll/detail/windows/shared_library_impl.hpp
+++ b/include/boost/dll/detail/windows/shared_library_impl.hpp
@@ -15,7 +15,7 @@
 #include <boost/dll/detail/windows/path_from_handle.hpp>
 
 #include <boost/move/utility.hpp>
-#include <boost/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 
 #include <boost/winapi/dll.hpp>
 
@@ -123,7 +123,7 @@ public:
     }
 
     void swap(shared_library_impl& rhs) BOOST_NOEXCEPT {
-        boost::swap(handle_, rhs.handle_);
+        boost::core::invoke_swap(handle_, rhs.handle_);
     }
 
     boost::dll::fs::path full_module_path(boost::dll::fs::error_code &ec) const {


### PR DESCRIPTION
`boost::swap` is deprecated and will be removed. Use `boost::core::invoke_swap` as a replacement.