### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,33 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/dll
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/filesystem//boost_filesystem
+        <source>/boost/function//boost_function
+        <source>/boost/move//boost_move
+        <source>/boost/predef//boost_predef
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/spirit//boost_spirit
+        <source>/boost/system//boost_system
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_index//boost_type_index
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/winapi//boost_winapi
+        <include>include
+    ;
+
+explicit
+    [ alias boost_dll ]
+    [ alias all : boost_dll test ]
+    ;
+
+call-if : boost-library dll
+    ;

--- a/build.jam
+++ b/build.jam
@@ -5,29 +5,32 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/filesystem//boost_filesystem
+    /boost/function//boost_function
+    /boost/move//boost_move
+    /boost/predef//boost_predef
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/spirit//boost_spirit
+    /boost/system//boost_system
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_index//boost_type_index
+    /boost/type_traits//boost_type_traits
+    /boost/winapi//boost_winapi ;
+
 project /boost/dll
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/filesystem//boost_filesystem
-        <library>/boost/function//boost_function
-        <library>/boost/move//boost_move
-        <library>/boost/predef//boost_predef
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/spirit//boost_spirit
-        <library>/boost/system//boost_system
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_index//boost_type_index
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/winapi//boost_winapi
         <include>include
     ;
 
 explicit
-    [ alias boost_dll ]
+    [ alias boost_dll : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_dll test ]
     ;
 
 call-if : boost-library dll
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/dll

--- a/build.jam
+++ b/build.jam
@@ -7,20 +7,20 @@ import project ;
 
 project /boost/dll
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/filesystem//boost_filesystem
-        <source>/boost/function//boost_function
-        <source>/boost/move//boost_move
-        <source>/boost/predef//boost_predef
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/spirit//boost_spirit
-        <source>/boost/system//boost_system
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_index//boost_type_index
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/winapi//boost_winapi
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/filesystem//boost_filesystem
+        <library>/boost/function//boost_function
+        <library>/boost/move//boost_move
+        <library>/boost/predef//boost_predef
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/spirit//boost_spirit
+        <library>/boost/system//boost_system
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_index//boost_type_index
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/winapi//boost_winapi
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/dll
     : common-requirements

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -24,13 +24,14 @@ local RDYNAMIC = <target-os>freebsd:<linkflags>"-rdynamic" <target-os>solaris:<l
 
 
 # Static library that is not linked with any of the boost libs
-lib static_plugin : ../example/tutorial4/static_plugin.cpp : <link>static <define>BOOST_SYSTEM_NO_DEPRECATED $(RDYNAMIC) ;
-lib static_refcounting_plugin : ../example/tutorial8/refcounting_plugin.cpp : <link>static <define>BOOST_SYSTEM_NO_DEPRECATED <variant>release $(RDYNAMIC) ;
+lib static_plugin : ../example/tutorial4/static_plugin.cpp : <link>static <define>BOOST_SYSTEM_NO_DEPRECATED $(RDYNAMIC) <library>/boost/dll//boost_dll ;
+lib static_refcounting_plugin : ../example/tutorial8/refcounting_plugin.cpp : <link>static <define>BOOST_SYSTEM_NO_DEPRECATED <variant>release $(RDYNAMIC) <library>/boost/dll//boost_dll ;
 
 
 project
    : source-location .
    : requirements
+      <library>/boost/dll//boost_dll
       [ requires cxx11_rvalue_references ]
       [ requires cxx11_static_assert ]
    # linux

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -7,11 +7,15 @@
 
 # For more information, see http://www.boost.org
 
+require-b2 5.0.1 ;
+
+import-search /boost/config/checks ;
+
 # bring in rules for testing
 import testing ;
 import path ;
 
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 local RDYNAMIC = <target-os>freebsd:<linkflags>"-rdynamic" <target-os>solaris:<linkflags>"-Bdynamic" <target-os>aix:<linkflags>"-rdynamic"
     <target-os>qnxnto,<toolset>qcc:<linkflags>"-Bdynamic" <target-os>qnxnto,<toolset>gcc:<linkflags>"-rdynamic"


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.