### PR TITLE
Add constructor taking native_handle_t

### DIFF
--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -53,6 +53,10 @@ public:
         sl.handle_ = NULL;
     }
 
+    shared_library_impl(native_handle_t handle)
+        : handle_(handle)
+    {}
+
     shared_library_impl & operator=(BOOST_RV_REF(shared_library_impl) sl) BOOST_NOEXCEPT {
         swap(sl);
         return *this;

--- a/include/boost/dll/detail/windows/shared_library_impl.hpp
+++ b/include/boost/dll/detail/windows/shared_library_impl.hpp
@@ -45,6 +45,10 @@ public:
         sl.handle_ = NULL;
     }
 
+    shared_library_impl(native_handle_t handle)
+        : handle_(handle)
+    {}
+
     shared_library_impl & operator=(BOOST_RV_REF(shared_library_impl) sl) BOOST_NOEXCEPT {
         swap(sl);
         return *this;

--- a/include/boost/dll/shared_library.hpp
+++ b/include/boost/dll/shared_library.hpp
@@ -138,6 +138,15 @@ public:
     }
 
     /*!
+    * Takes ownership of a loaded library.
+    *
+    * \param handle The native handle.
+    */
+    explicit shared_library(native_handle_t handle)
+        : base_t(handle)
+    {}
+
+    /*!
     * Assignment operator. If this->is_loaded() then calls this->unload(). Does not invalidate existing symbols and functions loaded from lib.
     *
     * \param lib A shared library to assign from.


### PR DESCRIPTION
Calls to dlopen() will always fail on FreeBSD if ambient authority is disabled (i.e. process is in capsicum mode). For these cases, FreeBSD offers fdlopen(). The new constructor allows the user to explicitly call fdlopen() and then use Boost.DLL to manage the loaded plugin.

Android's libc (Bionic) also has fdlopen(), but under a different name: android_dlopen_ext().

As Linux implements a sandboxing model closer to Capsicum (that's already planned in the roadmap for the Landlock subsystem), similar restrictions will hit glibc and we might see fdlopen() in glibc as well.

This patch resolves issue #69 

(_This patch was made by a friend of mine and I am just submitting it._)