### PR TITLE
Switch to std::shared_ptr from boost::shared_ptr and provide a BOOST_…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             # UBSAN complains on vtables and fails. No ',undefined -fno-sanitize-recover=undefined' flags!
             cxxflags: "cxxflags=--coverage -fsanitize=address,leak -DBOOST_TRAVISCI_BUILD"
             linkflags: "linkflags=--coverage -lasan"
-            launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.10"
+            launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8"
             gcov_tool: "gcov-14"
             ignore_coverage: "*/detail/pe_info.hpp */detail/macho_info.hpp */filesystem/src/*"
           - toolset: gcc-14
@@ -34,7 +34,7 @@ jobs:
             # UBSAN complains on vtables and fails. No ',undefined -fno-sanitize-recover=undefined' flags!
             cxxflags: "cxxflags=--coverage -fsanitize=address,leak -DBOOST_DLL_USE_STD_FS -DBOOST_TRAVISCI_BUILD"
             linkflags: "linkflags=--coverage -lasan"
-            launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.9"
+            launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8"
             gcov_tool: "gcov-14"
             ignore_coverage: "*/detail/pe_info.hpp */detail/macho_info.hpp */filesystem/src/*"
           - toolset: clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - toolset: gcc-12
+          - toolset: gcc-14
             cxxstd: "11,14,17,2a"
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             # UBSAN complains on vtables and fails. No ',undefined -fno-sanitize-recover=undefined' flags!
             cxxflags: "cxxflags=--coverage -fsanitize=address,leak -DBOOST_TRAVISCI_BUILD"
             linkflags: "linkflags=--coverage -lasan"
             launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8"
-            gcov_tool: "gcov-12"
+            gcov_tool: "gcov-14"
             ignore_coverage: "*/detail/pe_info.hpp */detail/macho_info.hpp */filesystem/src/*"
-          - toolset: gcc-12
+          - toolset: gcc-14
             cxxstd: "17,2a"
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             # UBSAN complains on vtables and fails. No ',undefined -fno-sanitize-recover=undefined' flags!
             cxxflags: "cxxflags=--coverage -fsanitize=address,leak -DBOOST_DLL_USE_STD_FS -DBOOST_TRAVISCI_BUILD"
             linkflags: "linkflags=--coverage -lasan"
@@ -41,6 +41,10 @@ jobs:
             compiler: clang++-10
             cxxstd: "11,14,17,2a"
             os: ubuntu-20.04
+          - toolset: clang-18
+            compiler: clang++-18
+            cxxstd: "11,14,17,2a"
+            os: ubuntu-24.04
           #- toolset: clang
           #  cxxstd: "11,14,17,2a"
           #  os: macos-10.15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             # UBSAN complains on vtables and fails. No ',undefined -fno-sanitize-recover=undefined' flags!
             cxxflags: "cxxflags=--coverage -fsanitize=address,leak -DBOOST_TRAVISCI_BUILD"
             linkflags: "linkflags=--coverage -lasan"
-            launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8"
+            launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.10"
             gcov_tool: "gcov-14"
             ignore_coverage: "*/detail/pe_info.hpp */detail/macho_info.hpp */filesystem/src/*"
           - toolset: gcc-14
@@ -34,12 +34,12 @@ jobs:
             # UBSAN complains on vtables and fails. No ',undefined -fno-sanitize-recover=undefined' flags!
             cxxflags: "cxxflags=--coverage -fsanitize=address,leak -DBOOST_DLL_USE_STD_FS -DBOOST_TRAVISCI_BUILD"
             linkflags: "linkflags=--coverage -lasan"
-            launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8"
-            gcov_tool: "gcov-12"
+            launcher: "testing.launcher=LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.9"
+            gcov_tool: "gcov-14"
             ignore_coverage: "*/detail/pe_info.hpp */detail/macho_info.hpp */filesystem/src/*"
           - toolset: clang
             cxxstd: "11,14,17,2a"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - toolset: clang-18
             cxxstd: "11,14,17,2a"
             os: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,9 @@ jobs:
             gcov_tool: "gcov-12"
             ignore_coverage: "*/detail/pe_info.hpp */detail/macho_info.hpp */filesystem/src/*"
           - toolset: clang
-            compiler: clang++-10
             cxxstd: "11,14,17,2a"
             os: ubuntu-20.04
           - toolset: clang-18
-            compiler: clang++-18
             cxxstd: "11,14,17,2a"
             os: ubuntu-24.04
           #- toolset: clang
@@ -88,11 +86,6 @@ jobs:
           ./bootstrap.sh
           ./b2 -d0 headers
           ./b2 -j4 variant=debug tools/inspect/build
-
-      - name: Create user-config.jam
-        if: matrix.compiler
-        run: |
-          echo "using ${{matrix.toolset}} : : ${{matrix.compiler}} ;" > ~/user-config.jam
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  # ASAN complains:
+  # ==5457==ERROR: AddressSanitizer: odr-violation (0x7f6112f03b00):
+  # [1] size=8 'rvalue_reference_to_internal_integer' test/test_library.cpp:122:7 in bin.v2/libs/dll/test/gcc-14/debug/x86_64/cxxstd-17-iso/threading-multi/visibility-hidden/libtest_library.so
+  # [2] size=8 'rvalue_reference_to_internal_integer' test/test_library.cpp:122:7 in bin.v2/libs/dll/test/gcc-14/debug/x86_64/cxxstd-17-iso/threading-multi/visibility-hidden/libtest_library.so.1.88.0
+  ASAN_OPTIONS: detect_odr_violation=0
 
 jobs:
   posix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ target_link_libraries(boost_dll
     Boost::core
     Boost::filesystem
     Boost::predef
-    Boost::smart_ptr
     Boost::system
     Boost::throw_exception
     Boost::type_index

--- a/build.jam
+++ b/build.jam
@@ -11,7 +11,6 @@ constant boost_dependencies :
     /boost/core//boost_core
     /boost/filesystem//boost_filesystem
     /boost/predef//boost_predef
-    /boost/smart_ptr//boost_smart_ptr
     /boost/system//boost_system
     /boost/throw_exception//boost_throw_exception
     /boost/type_index//boost_type_index

--- a/example/getting_started.cpp
+++ b/example/getting_started.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
 
     //[getting_started_imports_c_variable
     // Importing pure C variable
-    shared_ptr<int> c_var = dll::import_symbol<int>(
+    std::shared_ptr<int> c_var = dll::import_symbol<int>(
             path_to_shared_library, "c_variable_name"
         );
     //]
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
 
     //[getting_started_imports_cpp_variable
     // Importing  variable.
-    shared_ptr<std::string> cpp_var = dll::import_symbol<std::string>(
+    std::shared_ptr<std::string> cpp_var = dll::import_symbol<std::string>(
             path_to_shared_library, "cpp_variable_name"
         );
     //]

--- a/example/tutorial5/load_all.cpp
+++ b/example/tutorial5/load_all.cpp
@@ -12,7 +12,6 @@
 #include "../tutorial4/static_plugin.hpp"
 #include <boost/dll/runtime_symbol_info.hpp> // for program_location()
 #include <boost/dll/shared_library.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/filesystem.hpp>
 
 #include <map>

--- a/include/boost/dll/config.hpp
+++ b/include/boost/dll/config.hpp
@@ -82,7 +82,6 @@ namespace boost { namespace dll { namespace detail {
     template <class T>
     using shared_ptr = boost::shared_ptr<T>;
     using boost::make_shared;
-
 }}}
 
 #else  // BOOST_DLL_USE_STD_FS

--- a/include/boost/dll/config.hpp
+++ b/include/boost/dll/config.hpp
@@ -19,6 +19,10 @@
 /// Define this macro to make Boost.DLL use C++17's std::filesystem::path and std::system_error.
 #define BOOST_DLL_USE_STD_FS BOOST_DLL_USE_STD_FS
 
+/// Define this macro to make Boost.DLL use boost::shared_ptr instead of std::shared_ptr. This macro will be removed
+/// after a few releases, consider migrating to std::shared_ptr. 
+#define BOOST_DLL_USE_BOOST_SHARED_PTR BOOST_DLL_USE_BOOST_SHARED_PTR
+
 /// This namespace contains aliases to the Boost or C++17 classes. Aliases are configured using BOOST_DLL_USE_STD_FS macro.
 namespace boost { namespace dll { namespace fs {
 
@@ -68,6 +72,30 @@ using boost::system::system_error;
 }}}
 
 #endif // BOOST_DLL_USE_STD_FS
+
+
+#ifdef BOOST_DLL_USE_BOOST_SHARED_PTR
+
+#include <boost/make_shared.hpp>
+
+namespace boost { namespace dll { namespace detail {
+    template <class T>
+    using shared_ptr = boost::shared_ptr<T>;
+    using boost::make_shared;
+
+}}}
+
+#else  // BOOST_DLL_USE_STD_FS
+
+#include <memory>
+
+namespace boost { namespace dll { namespace detail {
+    template <class T>
+    using shared_ptr = std::shared_ptr<T>;
+    using std::make_shared;
+}}}
+
+#endif  // BOOST_DLL_USE_STD_FS
 
 #endif // BOOST_DLL_DETAIL_PUSH_OPTIONS_HPP
 

--- a/include/boost/dll/import.hpp
+++ b/include/boost/dll/import.hpp
@@ -111,7 +111,8 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_symbol(const boost::dll::fs::path& lib, cons
     using type = boost::dll::detail::import_type<T>;
 
     auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(lib, mode);
-    return type(p, std::addressof(p->get<T>(name)));
+    auto* addr = std::addressof(p->get<T>(name));
+    return type(std::move(p), addr);
 }
 
 //! \overload boost::dll::import_symbol(const boost::dll::fs::path& lib, const char* name, load_mode::type mode)
@@ -145,7 +146,8 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_symbol(shared_library&& lib, const char* nam
     auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(
         std::move(lib)
     );
-    return type(p, std::addressof(p->get<T>(name)));
+    auto* addr = std::addressof(p->get<T>(name));
+    return type(std::move(p), addr);
 }
 
 //! \overload boost::dll::import_symbol(const boost::dll::fs::path& lib, const char* name, load_mode::type mode)
@@ -203,7 +205,8 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_alias(const boost::dll::fs::path& lib, const
     using type = boost::dll::detail::import_type<T>;
 
     auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(lib, mode);
-    return type(p, p->get<T*>(name));
+    auto* addr = p->get<T*>(name);
+    return type(std::move(p), addr);
 }
 
 //! \overload boost::dll::import_alias(const boost::dll::fs::path& lib, const char* name, load_mode::type mode)
@@ -220,7 +223,8 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_alias(const shared_library& lib, const char*
     using type = boost::dll::detail::import_type<T>;
 
     auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(lib);
-    return type(p, p->get<T*>(name));
+    auto* addr = p->get<T*>(name);
+    return type(std::move(p), addr);
 }
 
 //! \overload boost::dll::import_alias(const boost::dll::fs::path& lib, const char* name, load_mode::type mode)
@@ -237,7 +241,8 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_alias(shared_library&& lib, const char* name
     auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(
         std::move(lib)
     );
-    return type(p, p->get<T*>(name));
+    auto* addr = p->get<T*>(name);
+    return type(std::move(p), addr);
 }
 
 //! \overload boost::dll::import_alias(const boost::dll::fs::path& lib, const char* name, load_mode::type mode)

--- a/include/boost/dll/import.hpp
+++ b/include/boost/dll/import.hpp
@@ -9,7 +9,6 @@
 #define BOOST_DLL_IMPORT_HPP
 
 #include <boost/dll/config.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/dll/shared_library.hpp>
 
 #include <memory>  // std::addressof
@@ -32,10 +31,10 @@ namespace detail {
     template <class T>
     class library_function {
         // Copying of `boost::dll::shared_library` is very expensive, so we use a `shared_ptr` to make it faster.
-        boost::shared_ptr<T>   f_;
+        boost::dll::detail::shared_ptr<T>   f_;
 
     public:
-        inline library_function(const boost::shared_ptr<shared_library>& lib, T* func_ptr) noexcept
+        inline library_function(const boost::dll::detail::shared_ptr<shared_library>& lib, T* func_ptr) noexcept
             : f_(lib, func_ptr)
         {}
 
@@ -55,11 +54,10 @@ namespace detail {
         }
     };
 
-
     template <class T>
     using import_type = typename std::conditional<
         std::is_object<T>::value,
-        boost::shared_ptr<T>,
+        boost::dll::detail::shared_ptr<T>,
         boost::dll::detail::library_function<T>
     >::type;
 } // namespace detail
@@ -71,7 +69,8 @@ namespace detail {
 
 
 /*!
-* Returns callable object or boost::shared_ptr<T> that holds the symbol imported
+* Returns callable object or std::shared_ptr<T> (boost::shared_ptr<T> if
+* BOOST_DLL_USE_BOOST_SHARED_PTR is defined) that holds the symbol imported
 * from the loaded library. Returned value refcounts usage
 * of the loaded shared library, so that it won't get unload until all copies of return value
 * are not destroyed.
@@ -90,7 +89,7 @@ namespace detail {
 * \endcode
 *
 * \code
-* boost::shared_ptr<int> i = import_symbol<int>("test_lib.so", "integer_name");
+* std::shared_ptr<int> i = import_symbol<int>("test_lib.so", "integer_name");
 * \endcode
 *
 * \b Template \b parameter \b T:    Type of the symbol that we are going to import. Must be explicitly specified.
@@ -99,7 +98,8 @@ namespace detail {
 * \param name Null-terminated C or C++ mangled name of the function to import. Can handle std::string, char*, const char*.
 * \param mode An mode that will be used on library load.
 *
-* \return callable object if T is a function type, or boost::shared_ptr<T> if T is an object type.
+* \return callable object if T is a function type, or std::shared_ptr<T> (boost::shared_ptr<T> if
+* BOOST_DLL_USE_BOOST_SHARED_PTR is defined) if T is an object type.
 *
 * \throw \forcedlinkfs{system_error} if symbol does not exist or if the DLL/DSO was not loaded.
 *       Overload that accepts path also throws std::bad_alloc in case of insufficient memory.
@@ -110,7 +110,7 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_symbol(const boost::dll::fs::path& lib, cons
 {
     using type = boost::dll::detail::import_type<T>;
 
-    auto p = boost::make_shared<boost::dll::shared_library>(lib, mode);
+    auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(lib, mode);
     return type(p, std::addressof(p->get<T>(name)));
 }
 
@@ -127,7 +127,7 @@ template <class T>
 BOOST_DLL_IMPORT_RESULT_TYPE import_symbol(const shared_library& lib, const char* name) {
     using type = boost::dll::detail::import_type<T>;
 
-    auto p = boost::make_shared<boost::dll::shared_library>(lib);
+    auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(lib);
     return type(p, std::addressof(p->get<T>(name)));
 }
 
@@ -142,7 +142,7 @@ template <class T>
 BOOST_DLL_IMPORT_RESULT_TYPE import_symbol(shared_library&& lib, const char* name) {
     using type = boost::dll::detail::import_type<T>;
 
-    auto p = boost::make_shared<boost::dll::shared_library>(
+    auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(
         std::move(lib)
     );
     return type(p, std::addressof(p->get<T>(name)));
@@ -158,7 +158,8 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_symbol(shared_library&& lib, const std::stri
 
 
 /*!
-* Returns callable object or boost::shared_ptr<T> that holds the symbol imported
+* Returns callable object or std::shared_ptr<T> (boost::shared_ptr<T> if
+* BOOST_DLL_USE_BOOST_SHARED_PTR is defined) that holds the symbol imported
 * from the loaded library. Returned value refcounts usage
 * of the loaded shared library, so that it won't get unload until all copies of return value
 * are not destroyed.
@@ -177,7 +178,7 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_symbol(shared_library&& lib, const std::stri
 * \endcode
 *
 * \code
-* boost::shared_ptr<int> i = import_alias<int>("test_lib.so", "integer_alias_name");
+* std::shared_ptr<int> i = import_alias<int>("test_lib.so", "integer_alias_name");
 * \endcode
 *
 * \code
@@ -189,7 +190,8 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_symbol(shared_library&& lib, const std::stri
 * \param name Null-terminated C or C++ mangled name of the function or variable to import. Can handle std::string, char*, const char*.
 * \param mode An mode that will be used on library load.
 *
-* \return callable object if T is a function type, or boost::shared_ptr<T> if T is an object type.
+* \return callable object if T is a function type, or std::shared_ptr<T> (boost::shared_ptr<T> if
+* BOOST_DLL_USE_BOOST_SHARED_PTR is defined) if T is an object type.
 *
 * \throw \forcedlinkfs{system_error} if symbol does not exist or if the DLL/DSO was not loaded.
 *       Overload that accepts path also throws std::bad_alloc in case of insufficient memory.
@@ -200,7 +202,7 @@ BOOST_DLL_IMPORT_RESULT_TYPE import_alias(const boost::dll::fs::path& lib, const
 {
     using type = boost::dll::detail::import_type<T>;
 
-    auto p = boost::make_shared<boost::dll::shared_library>(lib, mode);
+    auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(lib, mode);
     return type(p, p->get<T*>(name));
 }
 
@@ -217,7 +219,7 @@ template <class T>
 BOOST_DLL_IMPORT_RESULT_TYPE import_alias(const shared_library& lib, const char* name) {
     using type = boost::dll::detail::import_type<T>;
 
-    auto p = boost::make_shared<boost::dll::shared_library>(lib);
+    auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(lib);
     return type(p, p->get<T*>(name));
 }
 
@@ -232,7 +234,7 @@ template <class T>
 BOOST_DLL_IMPORT_RESULT_TYPE import_alias(shared_library&& lib, const char* name) {
     using type = boost::dll::detail::import_type<T>;
 
-    auto p = boost::make_shared<boost::dll::shared_library>(
+    auto p = boost::dll::detail::make_shared<boost::dll::shared_library>(
         std::move(lib)
     );
     return type(p, p->get<T*>(name));

--- a/include/boost/dll/import_mangled.hpp
+++ b/include/boost/dll/import_mangled.hpp
@@ -19,7 +19,7 @@
 #  error This file requires C++11 at least!
 #endif
 
-#include <boost/make_shared.hpp>
+#include <boost/dll/config.hpp>
 #include <boost/dll/smart_library.hpp>
 #include <boost/dll/detail/import_mangled_helpers.hpp>
 
@@ -39,10 +39,10 @@ namespace detail
 template <class ... Ts>
 class mangled_library_function {
     // Copying of `boost::dll::shared_library` is very expensive, so we use a `shared_ptr` to make it faster.
-    boost::shared_ptr<shared_library> lib_;
+    boost::dll::detail::shared_ptr<shared_library> lib_;
     function_tuple<Ts...>   f_;
 public:
-    constexpr mangled_library_function(const boost::shared_ptr<shared_library>& lib, Ts*... func_ptr) noexcept
+    constexpr mangled_library_function(const boost::dll::detail::shared_ptr<shared_library>& lib, Ts*... func_ptr) noexcept
         : lib_(lib)
         , f_(func_ptr...)
     {}
@@ -72,11 +72,11 @@ template <class Class, class ... Ts>
 class mangled_library_mem_fn<Class, sequence<Ts...>> {
     // Copying of `boost::dll::shared_library` is very expensive, so we use a `shared_ptr` to make it faster.
     typedef mem_fn_tuple<Ts...> call_tuple_t;
-    boost::shared_ptr<shared_library>   lib_;
+    boost::dll::detail::shared_ptr<shared_library>   lib_;
     call_tuple_t f_;
 
 public:
-    constexpr mangled_library_mem_fn(const boost::shared_ptr<shared_library>& lib, typename Ts::mem_fn... func_ptr) noexcept
+    constexpr mangled_library_mem_fn(const boost::dll::detail::shared_ptr<shared_library>& lib, typename Ts::mem_fn... func_ptr) noexcept
         : lib_(lib)
         , f_(func_ptr...)
     {}
@@ -111,7 +111,7 @@ struct mangled_import_type<sequence<Args...>, true,false,false> //is function
            const std::string& name)
     {
         return type(
-                boost::make_shared<shared_library>(p.shared_lib()),
+                boost::dll::detail::make_shared<shared_library>(p.shared_lib()),
                 std::addressof(p.get_function<Args>(name))...);
     }
 };
@@ -129,7 +129,7 @@ struct mangled_import_type<sequence<Class, Args...>, false, true, false> //is me
             const std::string & name,
             sequence<ArgsIn...> * )
     {
-        return type(boost::make_shared<shared_library>(p.shared_lib()),
+        return type(boost::dll::detail::make_shared<shared_library>(p.shared_lib()),
                     p.get_mem_fn<typename ArgsIn::class_type, typename ArgsIn::func_type>(name)...);
     }
 
@@ -145,14 +145,14 @@ struct mangled_import_type<sequence<Class, Args...>, false, true, false> //is me
 template <class T>
 struct mangled_import_type<sequence<T>, false, false, true> //is variable
 {
-    typedef boost::shared_ptr<T> type;
+    typedef boost::dll::detail::shared_ptr<T> type;
 
     static type make(
            const boost::dll::experimental::smart_library& p,
            const std::string& name)
     {
         return type(
-                boost::make_shared<shared_library>(p.shared_lib()),
+                boost::dll::detail::make_shared<shared_library>(p.shared_lib()),
                 std::addressof(p.get_variable<T>(name)));
     }
 
@@ -175,7 +175,7 @@ struct mangled_import_type<sequence<T>, false, false, true> //is variable
  */
 
 /*!
-* Returns callable object or boost::shared_ptr<T> that holds the symbol imported
+* Returns callable object or boost::dll::detail::shared_ptr<T> that holds the symbol imported
 * from the loaded library. Returned value refcounts usage
 * of the loaded shared library, so that it won't get unload until all copies of return value
 * are not destroyed.
@@ -191,7 +191,7 @@ struct mangled_import_type<sequence<T>, false, false, true> //is variable
 * \endcode
 *
 * \code
-* boost::shared_ptr<int> i = import_mangled<int>("test_lib.so", "integer_name");
+* boost::dll::detail::shared_ptr<int> i = import_mangled<int>("test_lib.so", "integer_name");
 * \endcode
 *
 * Additionally you can also import overloaded symbols, including member-functions.
@@ -218,7 +218,7 @@ struct mangled_import_type<sequence<T>, false, false, true> //is variable
 * \param name Null-terminated C or C++ mangled name of the function to import. Can handle std::string, char*, const char*.
 * \param mode An mode that will be used on library load.
 *
-* \return callable object if T is a function type, or boost::shared_ptr<T> if T is an object type.
+* \return callable object if T is a function type, or boost::dll::detail::shared_ptr<T> if T is an object type.
 *
 * \throw \forcedlinkfs{system_error} if symbol does not exist or if the DLL/DSO was not loaded.
 *       Overload that accepts path also throws std::bad_alloc in case of insufficient memory.
@@ -280,7 +280,7 @@ template <class ...Args>
 BOOST_DLL_MANGLED_IMPORT_RESULT_TYPE import_mangled(const shared_library& lib, const char* name) {
     typedef typename boost::dll::experimental::detail::mangled_import_type<detail::sequence<Args...>> type;
 
-    boost::shared_ptr<boost::dll::experimental::smart_library> p = boost::make_shared<boost::dll::experimental::smart_library>(lib);
+    boost::dll::detail::shared_ptr<boost::dll::experimental::smart_library> p = boost::dll::detail::make_shared<boost::dll::experimental::smart_library>(lib);
     return type::boostmake(p, name);
 }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -80,7 +80,7 @@ project
         [ run broken_library_info_test.cpp : : : <test-info>always_show_run_output <link>shared ]
         [ run empty_library_info_test.cpp : : empty_library : <test-info>always_show_run_output <link>shared ]
         [ run ../example/getting_started.cpp : : getting_started_library : <link>shared ]
-        [ run ../example/tutorial1/tutorial1.cpp : : my_plugin_sum : <link>shared ]
+        [ run ../example/tutorial1/tutorial1.cpp : : my_plugin_sum : <link>shared : tutorial1_std_shared_ptr ]
         [ run ../example/tutorial1/tutorial1.cpp : : my_plugin_sum : <link>shared <define>BOOST_DLL_USE_BOOST_SHARED_PTR : tutorial1_boost_shared_ptr ]
         [ run ../example/tutorial2/tutorial2.cpp : : my_plugin_aggregator : <link>shared ]
         [ run ../example/tutorial3/tutorial3.cpp : : my_plugin_aggregator my_plugin_sum : <link>shared ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -42,6 +42,7 @@ project
       <local-visibility>hidden
       <library>/boost/filesystem//boost_filesystem
       <library>/boost/system//boost_system
+      <library>/boost/smart_ptr//boost_smart_ptr
       <threading>multi
       <define>BOOST_SYSTEM_NO_DEPRECATED
     ;
@@ -80,6 +81,7 @@ project
         [ run empty_library_info_test.cpp : : empty_library : <test-info>always_show_run_output <link>shared ]
         [ run ../example/getting_started.cpp : : getting_started_library : <link>shared ]
         [ run ../example/tutorial1/tutorial1.cpp : : my_plugin_sum : <link>shared ]
+        [ run ../example/tutorial1/tutorial1.cpp : : my_plugin_sum : <link>shared <define>BOOST_DLL_USE_BOOST_SHARED_PTR : tutorial1_boost_shared_ptr ]
         [ run ../example/tutorial2/tutorial2.cpp : : my_plugin_aggregator : <link>shared ]
         [ run ../example/tutorial3/tutorial3.cpp : : my_plugin_aggregator my_plugin_sum : <link>shared ]
         [ run ../example/tutorial4/load_self.cpp ../example/tutorial4/static_plugin.cpp

--- a/test/shared_library_get_symbol_test.cpp
+++ b/test/shared_library_get_symbol_test.cpp
@@ -189,15 +189,11 @@ int main(int argc, char* argv[]) {
         BOOST_TEST(val == 15);   
     }
 
-    int& reference_to_internal_integer = sl.get<int&>("reference_to_internal_integer");
-    BOOST_TEST(reference_to_internal_integer == 0xFF0000);
+    int& ref_to_internal_integer = sl.get<int&>("reference_to_internal_integer");
+    BOOST_TEST(ref_to_internal_integer == 0xFF0000);
 
-#if defined(__has_feature)
-# if !__has_feature(address_sanitizer)
-    int&& rvalue_reference_to_internal_integer = sl.get<int&&>("rvalue_reference_to_internal_integer");
-    BOOST_TEST(rvalue_reference_to_internal_integer == 0xFF0000);
-# endif
-#endif
+    int&& rvalue_ref_to_internal_integer = sl.get<int&&>("rvalue_reference_to_internal_integer");
+    BOOST_TEST(rvalue_ref_to_internal_integer == 0xFF0000);
 
     return boost::report_errors();
 }

--- a/test/shared_library_get_symbol_test.cpp
+++ b/test/shared_library_get_symbol_test.cpp
@@ -12,6 +12,7 @@
 #include <boost/dll.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <functional>
+#include <memory>
 #include <boost/fusion/container.hpp>
 // lib functions
 
@@ -20,7 +21,7 @@ typedef void  (say_hello_func)  ();
 typedef int   (increment)       (int);
 
 typedef boost::fusion::vector<std::vector<int>, std::vector<int>, std::vector<int>, const std::vector<int>*, std::vector<int>* > do_share_res_t;
-typedef boost::shared_ptr<do_share_res_t> (do_share_t)(
+typedef std::shared_ptr<do_share_res_t> (do_share_t)(
             std::vector<int> v1,
             std::vector<int>& v2,
             const std::vector<int>& v3,
@@ -67,7 +68,7 @@ void refcountable_test(boost::dll::fs::path shared_library_path) {
         }
 
         std::vector<int> v1(1, 1), v2(2, 2), v3(3, 3), v4(4, 4), v5(1000, 5);
-        boost::shared_ptr<do_share_res_t> res = f(v1, v2, v3, &v4, &v5);
+        auto res = f(v1, v2, v3, &v4, &v5);
 
         BOOST_TEST(at_c<0>(*res).size() == 1); BOOST_TEST(at_c<0>(*res).front() == 1);
         BOOST_TEST(at_c<1>(*res).size() == 2); BOOST_TEST(at_c<1>(*res).front() == 2);
@@ -82,10 +83,10 @@ void refcountable_test(boost::dll::fs::path shared_library_path) {
     }
 
     {
-        boost::shared_ptr<int> i = import_symbol<int>(shared_library_path, "integer_g");
+        auto i = import_symbol<int>(shared_library_path, "integer_g");
         BOOST_TEST(*i == 100);
 
-        boost::shared_ptr<int> i2;
+        decltype(i) i2;
         i.swap(i2);
         BOOST_TEST(*i2 == 100);
     }
@@ -105,19 +106,19 @@ void refcountable_test(boost::dll::fs::path shared_library_path) {
     }
 
     {
-        boost::shared_ptr<const int> i = import_symbol<const int>(shared_library_path, "const_integer_g");
+        auto i = import_symbol<const int>(shared_library_path, "const_integer_g");
         BOOST_TEST(*i == 777);
 
-        boost::shared_ptr<const int> i2 = i;
+        auto i2 = i;
         i.reset();
         BOOST_TEST(*i2 == 777);
     }
 
     {
-        boost::shared_ptr<std::string> s = import_alias<std::string>(shared_library_path, "info");
+        auto s = import_alias<std::string>(shared_library_path, "info");
         BOOST_TEST(*s == "I am a std::string from the test_library (Think of me as of 'Hello world'. Long 'Hello world').");
 
-        boost::shared_ptr<std::string> s2;
+        decltype(s) s2;
         s.swap(s2);
         BOOST_TEST(*s2 == "I am a std::string from the test_library (Think of me as of 'Hello world'. Long 'Hello world').");
     }

--- a/test/shared_library_get_symbol_test.cpp
+++ b/test/shared_library_get_symbol_test.cpp
@@ -192,8 +192,12 @@ int main(int argc, char* argv[]) {
     int& reference_to_internal_integer = sl.get<int&>("reference_to_internal_integer");
     BOOST_TEST(reference_to_internal_integer == 0xFF0000);
 
+#if defined(__has_feature)
+# if !__has_feature(address_sanitizer)
     int&& rvalue_reference_to_internal_integer = sl.get<int&&>("rvalue_reference_to_internal_integer");
     BOOST_TEST(rvalue_reference_to_internal_integer == 0xFF0000);
+# endif
+#endif
 
     return boost::report_errors();
 }

--- a/test/test_library.cpp
+++ b/test/test_library.cpp
@@ -13,11 +13,10 @@
 
 #include <boost/dll/config.hpp>
 #include <boost/dll/alias.hpp>
+#include <memory>
 #include <iostream>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/fusion/container.hpp>
 
 #define LIBRARY_API BOOST_SYMBOL_EXPORT
@@ -49,7 +48,7 @@ namespace namespace1 { namespace namespace2 { namespace namespace3 {
         boost::fusion::vector<std::vector<int>, std::vector<int>, std::vector<int>, const std::vector<int>*, std::vector<int>* >
     do_share_res_t;
 
-    boost::shared_ptr<do_share_res_t> do_share(
+    std::shared_ptr<do_share_res_t> do_share(
             std::vector<int> v1,
             std::vector<int>& v2,
             const std::vector<int>& v3,
@@ -59,7 +58,7 @@ namespace namespace1 { namespace namespace2 { namespace namespace3 {
     {
         v2.back() = 777;
         v5->back() = 9990;
-        return boost::make_shared<do_share_res_t>(v1, v2, v3, v4, v5);
+        return std::make_shared<do_share_res_t>(v1, v2, v3, v4, v5);
     }
 
     std::string info("I am a std::string from the test_library (Think of me as of 'Hello world'. Long 'Hello world').");

--- a/test/test_library.cpp
+++ b/test/test_library.cpp
@@ -118,9 +118,6 @@ int internal_integer_i = 0xFF0000;
 extern "C" LIBRARY_API int& reference_to_internal_integer;
 int& reference_to_internal_integer = internal_integer_i;
 
-#if defined(__has_feature)
-# if !__has_feature(address_sanitizer)
 extern "C" LIBRARY_API int&& rvalue_reference_to_internal_integer;
 int&& rvalue_reference_to_internal_integer = static_cast<int&&>(internal_integer_i);
-# endif
-#endif
+

--- a/test/test_library.cpp
+++ b/test/test_library.cpp
@@ -118,6 +118,9 @@ int internal_integer_i = 0xFF0000;
 extern "C" LIBRARY_API int& reference_to_internal_integer;
 int& reference_to_internal_integer = internal_integer_i;
 
+#if defined(__has_feature)
+# if !__has_feature(address_sanitizer)
 extern "C" LIBRARY_API int&& rvalue_reference_to_internal_integer;
 int&& rvalue_reference_to_internal_integer = static_cast<int&&>(internal_integer_i);
-
+# endif
+#endif


### PR DESCRIPTION
…DLL_USE_BOOST_SHARED_PTR compatibility macro to restore the old behavior

Fixes https://github.com/boostorg/dll/issues/75