### PR TITLE
Replace deprecated BOOST_OS_ANDROID with BOOST_PLAT_ANDROID

### DIFF
--- a/include/boost/dll/alias.hpp
+++ b/include/boost/dll/alias.hpp
@@ -64,7 +64,7 @@ namespace boost { namespace dll {
 #else // #if BOOST_COMP_MSVC
 
 
-#if BOOST_OS_WINDOWS || BOOST_OS_ANDROID || BOOST_COMP_IBM
+#if BOOST_OS_WINDOWS || BOOST_PLAT_ANDROID || BOOST_COMP_IBM
 // There are some problems with mixing `__dllexport__` and `weak` using MinGW
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=17480
 //
@@ -177,7 +177,7 @@ namespace boost { namespace dll {
     /**/
 
 
-#if ((BOOST_COMP_GNUC && BOOST_OS_WINDOWS) || BOOST_OS_ANDROID || BOOST_COMP_IBM || defined(BOOST_DLL_FORCE_NO_WEAK_EXPORTS)) \
+#if ((BOOST_COMP_GNUC && BOOST_OS_WINDOWS) || BOOST_PLAT_ANDROID || BOOST_COMP_IBM || defined(BOOST_DLL_FORCE_NO_WEAK_EXPORTS)) \
     && !defined(BOOST_DLL_FORCE_ALIAS_INSTANTIATION) && !defined(BOOST_DLL_DOXYGEN)
 
 #define BOOST_DLL_ALIAS_SECTIONED(FunctionOrVar, AliasName, SectionName)                        \

--- a/include/boost/dll/detail/posix/path_from_handle.hpp
+++ b/include/boost/dll/detail/posix/path_from_handle.hpp
@@ -70,7 +70,7 @@ namespace boost { namespace dll { namespace detail {
 
 }}} // namespace boost::dll::detail
 
-#elif BOOST_OS_ANDROID
+#elif BOOST_PLAT_ANDROID
 
 #if !defined(BOOST_DLL_INTERFACE_UNIT)
 #include <boost/dll/runtime_symbol_info.hpp>
@@ -106,7 +106,7 @@ namespace boost { namespace dll { namespace detail {
 
 }}} // namespace boost::dll::detail
 
-#else // #if BOOST_OS_MACOS || BOOST_OS_IOS || BOOST_OS_ANDROID
+#else // #if BOOST_OS_MACOS || BOOST_OS_IOS || BOOST_PLAT_ANDROID
 
 // for dlinfo
 #if !defined(BOOST_DLL_INTERFACE_UNIT)

--- a/include/boost/dll/detail/posix/program_location_impl.hpp
+++ b/include/boost/dll/detail/posix/program_location_impl.hpp
@@ -163,7 +163,7 @@ namespace boost { namespace dll { namespace detail {
     }
 }}} // namespace boost::dll::detail
 
-#else  // BOOST_OS_LINUX || BOOST_OS_UNIX || BOOST_OS_HPUX || BOOST_OS_ANDROID
+#else  // BOOST_OS_LINUX || BOOST_OS_UNIX || BOOST_OS_HPUX || BOOST_PLAT_ANDROID
 
 namespace boost { namespace dll { namespace detail {
     inline boost::dll::fs::path program_location_impl(std::error_code &ec) {

--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -100,7 +100,7 @@ public:
             native_mode |= load_mode::rtld_local;
         }
 
-#if BOOST_OS_LINUX || BOOST_OS_ANDROID
+#if BOOST_OS_LINUX || BOOST_PLAT_ANDROID
         if (!sl.has_parent_path() && !(native_mode & load_mode::search_system_folders)) {
             sl = "." / sl;
         }


### PR DESCRIPTION
Fixes https://github.com/boostorg/dll/issues/115